### PR TITLE
Fix for IDA 7.2 (use SEARCH_DOWN  instead of BIN_SEARCH_FORWARD)

### DIFF
--- a/define_code_functions.py
+++ b/define_code_functions.py
@@ -81,7 +81,7 @@ if ((start_addr is not None and end_addr is not None) and (start_addr != BADADDR
 		curr_addr = start_addr
 		print "[make_code_functions.py] Running script to define code and functions on 0x%x to 0x%x" % (start_addr, end_addr)
 		while (curr_addr < end_addr):
-			next_unexplored = FindUnexplored(curr_addr, idaapi.BIN_SEARCH_FORWARD)
+			next_unexplored = FindUnexplored(curr_addr, idaapi.SEARCH_DOWN)
 			MakeCode(next_unexplored)		# We don't care whether it succeeds or fails so not storing retval
 			curr_addr = next_unexplored
 


### PR DESCRIPTION
According to https://www.hex-rays.com/products/ida/support/idadoc/284.shtml, there is no BIN_SEARCH_FORWARD argument for FindUnexplored. The new argument for FindUnexplored should be idaapi.SEARCH_DOWN. Using the BIN_SEARCH_FORWARD causes the IDA to look backward, combined with the condition curr_addr<end_addr makes out of bound code block unknown: 

Example:
Current Address is 0x400f08dc
End Address is 0x400f1cac
Next unexplored is 0x400f089f

Current Address is 0x400f089f
End Address is 0x400f1cac
Next unexplored is 0x400f089e

Current Address is 0x400f089e
End Address is 0x400f1cac
Next unexplored is 0x400f089d

Current Address is 0x400f089d
End Address is 0x400f1cac
Next unexplored is 0x400f089c

Both BIN_SEARCH_FORWARD and BIN_SEARCH_BACKWARD yield the same results. Thus we should use idaapi.SEARCH_DOWN instead of BIN_SEARCH_FORWARD. 

